### PR TITLE
using env(1) in shebang

### DIFF
--- a/abi-compliance-checker.pl
+++ b/abi-compliance-checker.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 ###########################################################################
 # ABI Compliance Checker (ACC) 1.98.8
 # A tool for checking backward compatibility of a C/C++ library API


### PR DESCRIPTION
In a system that installed perl manually (e.g. /usr/local/bin/perl), we want to use that insted of system defaults (i.e. /usr/bin/perl).
