### PR TITLE
Fix the objdump command line when the path contains spaces

### DIFF
--- a/abi-compliance-checker.pl
+++ b/abi-compliance-checker.pl
@@ -19829,7 +19829,7 @@ sub getSONAME($)
     if(not $ObjdumpCmd) {
         exitStatus("Not_Found", "can't find \"objdump\"");
     }
-    my $SonameCmd = "$ObjdumpCmd -x $Path 2>$TMP_DIR/null";
+    my $SonameCmd = "$ObjdumpCmd -x \"$Path\" 2>$TMP_DIR/null";
     if($OSgroup eq "windows") {
         $SonameCmd .= " | find \"SONAME\"";
     }


### PR DESCRIPTION
This PR fixes the error we get when running acc on a directory that contains spaces.
