### PR TITLE
.travis.yml: run script to check syntax in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+script:
+  - /usr/bin/perl abi-compliance-checker.pl


### PR DESCRIPTION
This adds really basic CI, just running the script without arguments to verify there are no syntax errors (such as the one from 26742a8c630e5dd42838a8c2faf4bb4f8e59c393).

You will need to enable travis-ci for this repository at travis-ci.org in order to use this.

To illustrate, I created this branch from the broken state, and made a pull request on my fork and it correctly identified the failure: https://github.com/scpeters/abi-compliance-checker/pull/1
