### PR TITLE
Quote string with symbols in c++filt call

### DIFF
--- a/modules/Internals/Mangling.pm
+++ b/modules/Internals/Mangling.pm
@@ -860,7 +860,7 @@ sub unmangleArray(@)
             }
             else
             {
-                my $Strings = join(" ", @_);
+                my $Strings = "'" . join("' '", @_) . "'";
                 my $Res = `$CppFiltCmd $NoStrip $Strings`;
                 if($?==139)
                 { # segmentation fault


### PR DESCRIPTION
For complex mangled symbols tool generates something like
'_Z...(bool)false...' during work and passes it as parameter for
c++filt.

To avoid c++filt execution error due such unescaped special symbols
the string with symbols needs to be quoted.