### PR TITLE
Header files should not be targeted if their include type is '2'

### DIFF
--- a/modules/Internals/SysFiles.pm
+++ b/modules/Internals/SysFiles.pm
@@ -2312,7 +2312,7 @@ sub addTargetHeaders($)
             my $Dir = getDirname($RecInc);
             
             if(familiarDirs($RegDir, $Dir) 
-            or $RecursiveIncludes{$LVer}{$RegHeader}{$RecInc}!=1)
+            or $RecursiveIncludes{$LVer}{$RegHeader}{$RecInc}<1)
             { # in the same directory or included by #include "..."
                 $In::Desc{$LVer}{"TargetHeader"}{getFilename($RecInc)} = 1;
             }


### PR DESCRIPTION
If you look at the definition of ParseIncludes() earlier in this file,:

* An include type of -1 means the include file was included with double quotes and exists relative to the including file (e.g., #include "foo.hpp").
* An include type of 1 means the include file was included with '<' and '>' (e.g., #include <foo>).
* An include type of 2 means the include file was included with double quotes, but it doesn't exist relative to the including file (e.g., #include "sys/types.h". The comment in ParseIncludes() states that this should be equivalent to including with '<' and '>'.

The logic here makes a header file "targeted" if its include type is not 1, but I don't believe that's correct, as a header file with include type 2 shouldn't be targeted either.