### PR TITLE
Redirect stderr of ‘objdump -f’ to null

### DIFF
--- a/modules/Internals/ElfTools.pm
+++ b/modules/Internals/ElfTools.pm
@@ -172,7 +172,8 @@ sub getArch_Object($)
             exitStatus("Not_Found", "can't find \"objdump\"");
         }
         
-        my $Cmd = $ObjdumpCmd." -f \"$Path\"";
+        my $TmpDir = $In::Opt{"Tmp"};
+        my $Cmd = $ObjdumpCmd." -f \"$Path\" 2>$TmpDir/null";
         
         my $Locale = $In::Opt{"Locale"};
         if($In::Opt{"OS"} eq "windows") {


### PR DESCRIPTION
Some scanned files may be not actual shared libraries but e.g. linker scripts, which can lead to useless warnings like these printed:

    objdump: /usr/lib/x86_64-linux-gnu/libm.so: File format not recognized
    objdump: /usr/lib/x86_64-linux-gnu/libpthread.so: File format not recognized
    objdump: /usr/lib/x86_64-linux-gnu/libc.so: File format not recognized

We already redirect `objdump -x` stderr to null in `getSONAME` function, this just makes the behavior more consistent.