### PR TITLE
Fix issue with C-code-compiled-as-C++ from 59e148d

### DIFF
--- a/modules/Internals/TUDump.pm
+++ b/modules/Internals/TUDump.pm
@@ -672,21 +672,20 @@ sub preChange($$$)
           # DO NOT MATCH:
           # #pragma GCC visibility push(default)
             my $Sentence_O = "$1$2$3$4";
-            
-            if($Sentence_O=~/\s+decltype\(/)
-            { # C++
-              # decltype(nullptr)
-                last;
-            }
-            else
-            {
-                $Content=~s/$Regex/$1$2c99_$3$4/g;
-                $In::Desc{$LVer}{"CppMode"} = 1;
-                if(not defined $Detected) {
-                    $Detected = $Sentence_O;
-                }
+
+            # C++
+            # decltype(nullptr)
+            # -> use temporary masking
+            $Content=~s/((?<=\s)decltype\(|(?<=decltype\()nullptr)/revert\@c99_$1/g;
+
+            $Content=~s/$Regex/$1$2c99_$3$4/g;
+            $In::Desc{$LVer}{"CppMode"} = 1;
+            if(not defined $Detected) {
+                $Detected = $Sentence_O;
             }
         }
+        # remove temporary masking from above
+        $Content=~s/revert\@c99_//g;
         if($Content=~s/([^\w\s]|\w\s+)(?<!operator )(delete)(\s*\()/$1c99_$2$3/g)
         { # MATCH:
           # int delete(...);


### PR DESCRIPTION
Said commit was meant to fix [Issue#64], but rather introduced new
problem -- when "decltype(nullptr)" was observed (happens on transitive
includes starting with standard C library headers, at least with newer
stdlibc++ as this is how includes are treated by gcc when it's passed
"-x c++-header"), the C-only-detection logic would short-circuit (or
give up) early, leaving C++ compatibility measures off, and in turn,
choking later on when valid C identifiers such as "new" are used
somewhere in the headers of the C project at hand.

This rather simplistic solution masks, item-wise, "decltype(nullptr)"
expression consisting of otherwise C++ compatibility mangling eligible
words, and restores them right after there's no danger this would happen
to them, because they need to be preserved (empirically tested).

[Issue#64] https://github.com/lvc/abi-compliance-checker/issues/64