### PR TITLE
Make sure TrName is indexed by $LVer so that mangling data between th…

### DIFF
--- a/modules/Internals/ABIDump.pm
+++ b/modules/Internals/ABIDump.pm
@@ -118,7 +118,7 @@ sub createABIDump($)
     {
         if(my $MnglName = $In::ABI{$LVer}{"SymbolInfo"}{$InfoId}{"MnglName"})
         {
-            if(my $Unmangled = getUnmangled($MnglName)) {
+            if(my $Unmangled = getUnmangled($MnglName, $LVer)) {
                 $In::ABI{$LVer}{"SymbolInfo"}{$InfoId}{"Unmangled"} = $Unmangled;
             }
         }

--- a/modules/Internals/GccAst.pm
+++ b/modules/Internals/GccAst.pm
@@ -1071,7 +1071,7 @@ sub getSymbolInfo($)
     }
     if($SInfo->{"MnglName"}=~/\A(_Z|\?)/)
     {
-        if(my $Unmangled = getUnmangled($SInfo->{"MnglName"}))
+        if(my $Unmangled = getUnmangled($SInfo->{"MnglName"}, $V))
         {
             if($Unmangled=~/\.\_\d/)
             {

--- a/modules/Internals/Mangling.pm
+++ b/modules/Internals/Mangling.pm
@@ -694,10 +694,10 @@ sub canonifyName($$)
     return $Name;
 }
 
-sub getUnmangled($)
+sub getUnmangled($$)
 {
-    if(defined $TrName{$_[0]}) {
-        return $TrName{$_[0]};
+    if(defined $TrName{$_[1]}{$_[0]}) {
+        return $TrName{$_[1]}{$_[0]};
     }
     
     return undef;
@@ -732,7 +732,7 @@ sub translateSymbols(@)
         if(index($Symbol, "_Z")==0)
         {
             push(@ZNames, $Symbol);
-            if($TrName{$Symbol})
+            if($TrName{$LVer}{$Symbol})
             { # already unmangled
                 next;
             }
@@ -758,9 +758,9 @@ sub translateSymbols(@)
             {
                 foreach my $M (keys(%{$Versioned{$MnglName}}))
                 {
-                    $TrName{$M} = canonifyName($Unmangled, "S");
-                    if(not $GccMangledName{$LVer}{$TrName{$M}}) {
-                        $GccMangledName{$LVer}{$TrName{$M}} = $M;
+                    $TrName{$LVer}{$M} = canonifyName($Unmangled, "S");
+                    if(not $GccMangledName{$LVer}{$TrName{$LVer}{$M}}) {
+                        $GccMangledName{$LVer}{$TrName{$LVer}{$M}} = $M;
                     }
                 }
             }
@@ -769,7 +769,7 @@ sub translateSymbols(@)
         foreach my $Symbol (@ZNames)
         {
             if(index($Symbol, "_ZTV")==0
-            and $TrName{$Symbol}=~/vtable for (.+)/)
+            and $TrName{$LVer}{$Symbol}=~/vtable for (.+)/)
             { # bind class name and v-table symbol
                 $In::ABI{$LVer}{"ClassVTable"}{$1} = $Symbol;
             }
@@ -782,12 +782,12 @@ sub translateSymbols(@)
         {
             if(my $Unmangled = pop(@UnmangledNames))
             {
-                $TrName{$MnglName} = formatName($Unmangled, "S");
-                $MangledName{$LVer}{$TrName{$MnglName}} = $MnglName;
+                $TrName{$LVer}{$MnglName} = formatName($Unmangled, "S");
+                $MangledName{$LVer}{$TrName{$LVer}{$MnglName}} = $MnglName;
             }
         }
     }
-    return \%TrName;
+    return \%{$TrName{$LVer}};
 }
 
 sub unmangleArray(@)
@@ -913,7 +913,7 @@ sub debugMangling($)
     {
         my $InfoId = $Mangled{$Mngl};
         
-        my $U1 = getUnmangled($Mngl);
+        my $U1 = getUnmangled($Mngl, $LVer);
         my $U2 = modelUnmangled($InfoId, "GCC", $LVer);
         my $U3 = mangleSymbol($InfoId, "GCC", $LVer);
         


### PR DESCRIPTION
…e two libraries do not collide during a comparison.

Hi,

I have been investigating a wrong incompatibility detected by abi-compliance-checker since version 2.0, with both lib1 and lib2 being exactly the same from a source compatibility side (ie compiled with the same public headers, with the same compiler, with the same flags and the same dependencies). In the end it resulted that abi-compliance-checker reported that a given symbol was removed and added under a another name. Actually just the mangled named was different, the unmangled name was similar. I tracked it down it the fact the sometimes we use the lib mangled name, and sometimes we fallback on the own abi-compliance-checker implementation of the mangling, which differs from gcc (in our case that was gcc 4.9).

By making sure that TrName is properly indexed by $LVer, then we also allow all side effect in line 774 of Mangling.pm (`$In::ABI{$LVer}{"ClassVTable"}{$1} = $Symbol`) to correctly happen in the second library, later leading to correct name mangling for the second library as well.

Cheers,
Romain