### PR TITLE
Make ABI checker work for VS2017 and VS2019 on Windows

### DIFF
--- a/modules/Internals/Utils.pm
+++ b/modules/Internals/Utils.pm
@@ -312,7 +312,7 @@ sub platformSpecs($)
             "-DSHSTDAPI_(x)=x",
             "-D_MSC_EXTENSIONS",
             "-DSECURITY_WIN32",
-            "-D_MSC_VER=1500",
+            "-D_MSC_VER=1920",
             "-D_USE_DECLSPECS_FOR_SAL",
             "-D__noop=\" \"",
             "-DDECLSPEC_DEPRECATED=\" \"",


### PR DESCRIPTION
1920 is the VS2019 RTW defined `_MSC_VER` version. This issue is described at https://github.com/lvc/abi-compliance-checker/issues/102