### PR TITLE
Fix XML report generation when changed type contains '&&'

### DIFF
--- a/modules/Internals/Basic.pm
+++ b/modules/Internals/Basic.pm
@@ -214,7 +214,7 @@ sub xmlSpecChars($)
         return $Str;
     }
     
-    $Str=~s/\&([^#]|\Z)/&amp;$1/g;
+    $Str=~s/\&(?!#([0-9]+|x[0-9a-fA-F]+);)/&amp;/g;
     $Str=~s/</&lt;/g;
     $Str=~s/>/&gt;/g;
     


### PR DESCRIPTION
The function xmlSpecChars in modules/Internal/Basic.pm would not
correctly replace two successive ampersand signs. The matching group
(^[#]|\Z) would consume the second '&'. Fix the issue by using a
negative assertion to lookahead in the string without consuming the
matched charcters.