### PR TITLE
Resolve typedefs for old classes in mergeBases

### DIFF
--- a/abi-compliance-checker.pl
+++ b/abi-compliance-checker.pl
@@ -2262,6 +2262,21 @@ sub mergeBases($)
             next;
         }
         my %Class_New = getType($ClassId_New, 2);
+
+        if($Class_Old{"Type"}!~/Class|Struct/)
+        { # was typedef
+            if($Level eq "Binary") {
+                next;
+            }
+            if($Level eq "Source")
+            {
+                %Class_Old = getPureType($ClassId_Old, 1);
+                if($Class_Old{"Type"}!~/Class|Struct/) {
+                    next;
+                }
+                $ClassId_Old = $Class_Old{"Tid"};
+            }
+        }
         if($Class_New{"Type"}!~/Class|Struct/)
         { # became typedef
             if($Level eq "Binary") {


### PR DESCRIPTION
The tool reports added bases in Source compatibillity when the abi dump(s) contain typedefs pointing to derived classes.
Only `Class_New` seems to be resolved to a pure type. `Class_Old` has no bases as it is typedef.

I am not sure whether these changes fully fix the problem.