### PR TITLE
Add statx to list of ignored functions

### DIFF
--- a/modules/Internals/TUDump.pm
+++ b/modules/Internals/TUDump.pm
@@ -45,6 +45,7 @@ my %C_Structure = map {$_=>1} (
     "stat64",
     "_stat64",
     "_stati64",
+    "statx",
     "if_nameindex",
     "usb_device",
     "sigaltstack",


### PR DESCRIPTION
statx (like stat, wait, flock, sysinfo) is both the name of a function:

    /usr/include/bits/statx-generic.h:int statx (int __dirfd, const char *__restrict __path, int __flags,
    /usr/include/bits/statx-generic.h:           unsigned int __mask, struct statx *__restrict __buf)

and a struct:

    /usr/include/linux/stat.h:struct statx {
    ...
    /usr/include/linux/stat.h:};

Typically `statx` always denotes the function and `struct statx` denotes the struct.

When usage of the struct is encountered in C++ code, abi-compliance-checker generates this line in dump1.h:

    statx* tmp_add_class_66;

which fails to compile:

    /tmp/qktDQcucCm/dump1.h:103:3: error: 'statx' does not name a type
       statx* tmp_add_class_66;
       ^~~~~

Ideally abi-compliance-checker should instead generate this in dump1.h:

    struct statx* tmp_add_class_66;

but determining when the `struct` qualifier should/shouldn't be used seems non-trivial, so lets take the same approach as we do for other similarly overloaded names.