### PR TITLE
Add arm architecture support for MacOS

### DIFF
--- a/modules/Internals/ElfTools.pm
+++ b/modules/Internals/ElfTools.pm
@@ -159,12 +159,15 @@ sub getArch_Object($)
         
         my $Cmd = $OtoolCmd." -hv -arch all \"$Path\"";
         my $Out = qx/$Cmd/;
-        
+
         if($Out=~/X86_64/i) {
             return "x86_64";
         }
         elsif($Out=~/X86/i) {
             return "x86";
+        }
+        elsif($Out=~/ARM64/i) {
+            return "arm";
         }
     }
     else


### PR DESCRIPTION
This enables to support arm64 architecture on Mac OS.

Test: abi-compliance-checker -test --gcc-path=/opt/homebrew/bin/gcc-12 on M1 Mac