### PR TITLE
skip built-in in header file

### DIFF
--- a/abi-compliance-checker.pl
+++ b/abi-compliance-checker.pl
@@ -8146,6 +8146,10 @@ sub getAffectedSymbols($$$)
             my $Target = "";
             if($PName)
             {
+                $PName =~ s/</&lt;/g;
+                $PName =~ s/>/&gt;/g;
+                $PName =~ s/&/&amp;/g;
+
                 $Target .= " param=\"$PName\"";
                 $Des=~s/parameter $PName /parameter \@param /;
             }

--- a/abi-compliance-checker.pl
+++ b/abi-compliance-checker.pl
@@ -6358,6 +6358,10 @@ sub getCheckedHeaders($)
         if(not isTargetHeader($Name, $LVer)) {
             next;
         }
+
+        if(index($Name,"<built-in>")!=-1) {
+            next;
+        }
         
         if(skipHeader($Name, $LVer)) {
             next;

--- a/abi-compliance-checker.pl
+++ b/abi-compliance-checker.pl
@@ -10358,7 +10358,7 @@ sub scenario()
     if($In::Opt{"SortDump"})
     {
         $Data::Dumper::Useperl = 1;
-        $Data::Dumper::Sortkeys = \&dump_sorting;
+        $Data::Dumper::Sortkeys = \&dumpSorting;
     }
     
     if(my $TargetLibsPath = $In::Opt{"TargetLibsPath"})

--- a/modules/Internals/Basic.pm
+++ b/modules/Internals/Basic.pm
@@ -159,7 +159,7 @@ sub specChars($)
     if(not $Str) {
         return $Str;
     }
-    $Str=~s/\&([^#]|\Z)/&amp;$1/g;
+    $Str=~s/\&[^#]/&amp;$1/g;
     $Str=~s/</&lt;/g;
     $Str=~s/\-\>/&#45;&gt;/g; # &minus;
     $Str=~s/>/&gt;/g;
@@ -214,7 +214,7 @@ sub xmlSpecChars($)
         return $Str;
     }
     
-    $Str=~s/\&([^#]|\Z)/&amp;$1/g;
+    $Str=~s/\&[^#]/&amp;$1/g;
     $Str=~s/</&lt;/g;
     $Str=~s/>/&gt;/g;
     


### PR DESCRIPTION
<built-in> can not display in html, because the "<>" should be replaced with &lt and &gt.
Otherwise, I think it is useless to show built-in in "Header files".